### PR TITLE
Handle mediafire /download/ url

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ async fn main() -> Result<()> {
                 return Err(anyhow!("Invalid Mediafire folder URL"));
             }
         }
-        "file" | "file_premium" => {
+        "file" | "file_premium" | "download" => {
             create_directory_if_not_exists(&path).await?;
             let response = file::get_info(&key).await?;
             if let Some(file_info) = response.file_info {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,7 @@ use std::io::Read;
 use std::path::PathBuf;
 
 pub fn match_mediafire_valid_url(url: &str) -> Option<(String, String)> {
-    let re = Regex::new(r"mediafire\.com/(file|file_premium|folder)/(\w+)").unwrap();
+    let re = Regex::new(r"mediafire\.com/(file|file_premium|folder|download)/(\w+)").unwrap();
     let matches = re.captures(url);
 
     if let Some(captures) = matches {


### PR DESCRIPTION
Hello, I  started using mediafire_rs recently and noticed that it didn't handle `mediafire.com/download/` urls.

From my knowledge /download/ urls are used for single files only so I send them to the handlers for single file downloads.

I've tested it and it seems to work properly.