### PR TITLE
Add socket support for downloading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,6 +348,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12a0bb14ac04a9fcf170d0bbbef949b44cc492f4452bd20c095636956f653642"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1168,7 +1174,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.9",
  "tokio",
  "tracing",
 ]
@@ -1187,7 +1193,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.9",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1324,6 +1330,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-socks",
  "tokio-util",
  "tower",
  "tower-service",
@@ -1714,11 +1721,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.9",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1794,6 +1821,18 @@ checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls",
  "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror 1.0.69",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ async-recursion = "1.0.5"
 clap = { version = "4.5.20", features = ["cargo"] }
 tokio = { version = "1.41.0", features = ["full"] }
 serde = { version = "1.0.211", features = ["serde_derive"] }
-reqwest = { version = "0.12.12", features = ["stream", "json", "gzip", "rustls-tls"] }
+reqwest = { version = "0.12.12", features = ["stream", "json", "gzip", "rustls-tls", "socks"] }
 
 [profile.release]
 lto = true

--- a/src/api/folder.rs
+++ b/src/api/folder.rs
@@ -1,5 +1,4 @@
 use crate::types::{get_content, get_info};
-use reqwest::get;
 
 const BASE_URL_GET_INFO: &str =
     "https://www.mediafire.com/api/1.5/folder/get_info.php?response_format=json&folder_key=";
@@ -7,21 +6,26 @@ const BASE_URL_GET_CONTENT: &str =
     "https://www.mediafire.com/api/1.5/folder/get_content.php?response_format=json&folder_key=";
 
 pub async fn get_content(
+    client: &reqwest::Client,
     folder_key: &str,
     content_type: &str,
     chunk: u32,
 ) -> Result<get_content::Response, reqwest::Error> {
-    return get(format!(
+    return client
+    .get(format!(
         "{BASE_URL_GET_CONTENT}{folder_key}&content_type={content_type}&chunk={chunk}"
     ))
+    .send()
     .await?
     .json::<get_content::Root>()
     .await
     .map(|root| root.response);
 }
 
-pub async fn get_info(folder_key: &str) -> Result<get_info::Response, reqwest::Error> {
-    return get(format!("{BASE_URL_GET_INFO}{folder_key}"))
+pub async fn get_info(client: &reqwest::Client, folder_key: &str) -> Result<get_info::Response, reqwest::Error> {
+    return client
+        .get(format!("{BASE_URL_GET_INFO}{folder_key}"))
+        .send()
         .await?
         .json::<get_info::Root>()
         .await
@@ -30,23 +34,28 @@ pub async fn get_info(folder_key: &str) -> Result<get_info::Response, reqwest::E
 
 #[cfg(test)]
 mod tests {
+    use crate::download::setup_client;
+
     use super::*;
 
     #[tokio::test]
     async fn test_get_folders_content() {
-        let response = get_content("xqub019s2e2l1", "folders", 1).await.unwrap();
+        let client = setup_client(None);
+        let response = get_content(&client, "xqub019s2e2l1", "folders", 1).await.unwrap();
         assert_eq!(response.folder_content.folderkey, "xqub019s2e2l1");
     }
 
     #[tokio::test]
     async fn test_get_files_content() {
-        let response = get_content("xqub019s2e2l1", "files", 1).await.unwrap();
+        let client = setup_client(None);
+        let response = get_content(&client, "xqub019s2e2l1", "files", 1).await.unwrap();
         assert_eq!(response.folder_content.folderkey, "xqub019s2e2l1");
     }
 
     #[tokio::test]
     async fn test_get_info() {
-        let response = get_info("xqub019s2e2l1").await.unwrap();
+        let client = setup_client(None);
+        let response = get_info(&client, "xqub019s2e2l1").await.unwrap();
         assert!(response.folder_info.is_some());
     }
 }

--- a/src/download.rs
+++ b/src/download.rs
@@ -9,12 +9,31 @@ use crate::utils::{create_directory_if_not_exists, parse_download_link};
 use anyhow::{anyhow, Result};
 use futures::StreamExt;
 use indicatif::ProgressBar;
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT_ENCODING, USER_AGENT};
 use std::path::PathBuf;
 use tokio::io::AsyncWriteExt;
 use tokio::try_join;
 
+/// Setup the HTTP/S client for rewquest
+pub fn setup_client(proxies: Option<Vec<String>>) -> reqwest::Client
+{
+    let mut builder = reqwest::Client::builder()
+        .use_rustls_tls()
+        .default_headers(HeaderMap::from_iter([
+            (USER_AGENT, HeaderValue::from_static("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36")),
+            (ACCEPT_ENCODING, HeaderValue::from_static("gzip")),
+        ]));
+
+    for proxy in proxies.into_iter().flatten() {
+        builder = builder.proxy(reqwest::Proxy::all(proxy).unwrap());
+    }
+
+    builder.build()
+        .unwrap()
+}
+
 #[async_recursion::async_recursion]
-pub async fn download_folder(folder_key: &str, path: PathBuf, chunk: u32) -> Result<()> {
+pub async fn download_folder(client: &reqwest::Client, folder_key: &str, path: PathBuf, chunk: u32) -> Result<()> {
     create_directory_if_not_exists(&path).await?;
     TOTAL_PROGRESS_BAR.set_message(format!(
         "{}",
@@ -26,29 +45,29 @@ pub async fn download_folder(folder_key: &str, path: PathBuf, chunk: u32) -> Res
             .unwrap()
     ));
 
-    let (folder_content, file_content) = get_folder_and_file_content(folder_key, chunk).await?;
+    let (folder_content, file_content) = get_folder_and_file_content(client, folder_key, chunk).await?;
 
     if let Some(files) = file_content.folder_content.files {
         download_files(files, &path).await?;
     }
 
     if let Some(folders) = folder_content.folder_content.folders {
-        download_folders(folders, &path, chunk).await?;
+        download_folders(client, folders, &path, chunk).await?;
     }
 
     if folder_content.folder_content.more_chunks == "yes"
         || file_content.folder_content.more_chunks == "yes"
     {
-        download_folder(folder_key, path, chunk + 1).await?;
+        download_folder(client, folder_key, path, chunk + 1).await?;
     }
 
     Ok(())
 }
 
-async fn get_folder_and_file_content(folder_key: &str, chunk: u32) -> Result<(Response, Response)> {
+async fn get_folder_and_file_content(client: &reqwest::Client, folder_key: &str, chunk: u32) -> Result<(Response, Response)> {
     match try_join!(
-        get_content(folder_key, "folders", chunk),
-        get_content(folder_key, "files", chunk)
+        get_content(client, folder_key, "folders", chunk),
+        get_content(client, folder_key, "files", chunk)
     ) {
         Ok((folder_content, file_content)) => Ok((folder_content, file_content)),
         Err(_) => Err(anyhow!("Invalid Mediafire URL")),
@@ -64,17 +83,17 @@ async fn download_files(files: Vec<File>, path: &PathBuf) -> Result<()> {
     Ok(())
 }
 
-async fn download_folders(folders: Vec<Folder>, path: &PathBuf, chunk: u32) -> Result<()> {
+async fn download_folders(client: &reqwest::Client, folders: Vec<Folder>, path: &PathBuf, chunk: u32) -> Result<()> {
     for folder in folders {
         let folder_path = path.join(&folder.name);
-        if let Err(e) = download_folder(&folder.folderkey, folder_path, chunk).await {
+        if let Err(e) = download_folder(client, &folder.folderkey, folder_path, chunk).await {
             return Err(e);
         }
     }
     Ok(())
 }
 
-pub async fn download_file(download_job: &DownloadJob) -> Result<()> {
+pub async fn download_file(client: &reqwest::Client, download_job: &DownloadJob) -> Result<()> {
     let bar = MULTI_PROGRESS_BAR.insert_from_back(1, ProgressBar::new(0));
     bar.set_style(PROGRESS_STYLE.clone());
     bar.set_prefix(
@@ -114,7 +133,6 @@ pub async fn download_file(download_job: &DownloadJob) -> Result<()> {
         "Getting download link..."
     });
 
-    let client = &CLIENT;
     let response = {
         let response = client
             .get(&download_job.file.links.normal_download)

--- a/src/global.rs
+++ b/src/global.rs
@@ -1,21 +1,11 @@
 use deadqueue::unlimited::Queue;
 use indicatif::{ProgressBar, ProgressStyle};
 use lazy_static::lazy_static;
-use reqwest::header::{HeaderMap, HeaderValue, ACCEPT_ENCODING, USER_AGENT};
 use tokio::sync::Mutex;
 
 use crate::types::download::DownloadJob;
 
 lazy_static! {
-    pub static ref CLIENT: reqwest::Client = reqwest::Client::builder()
-        .use_rustls_tls()
-        .default_headers(HeaderMap::from_iter([
-            (USER_AGENT, HeaderValue::from_static("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36")),
-            (ACCEPT_ENCODING, HeaderValue::from_static("gzip")),
-        ]))
-        .build()
-        .unwrap();
-
     pub static ref PROGRESS_STYLE_TOTAL_START: ProgressStyle = ProgressStyle::default_bar()
         .progress_chars("-> ")
         .template("{spinner} Fetching data · {msg:.blue}")

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,15 +54,15 @@ async fn main() -> Result<()> {
     let url = matches.get_one::<String>("URL").unwrap();
     let path = matches.get_one::<PathBuf>("output").unwrap().to_path_buf();
     let max = *matches.get_one::<usize>("max").unwrap();
-	let proxies : Option<Vec<String>> = matches.get_one::<PathBuf>("proxy").map(|path|
-	{
-		let proxy_file = File::open(path).unwrap();
-		io::BufReader::new(proxy_file).lines()
-			.map_while(Result::ok)
-			.collect()
-	});
+    let proxies : Option<Vec<String>> = matches.get_one::<PathBuf>("proxy").map(|path|
+    {
+        let proxy_file = File::open(path).unwrap();
+        io::BufReader::new(proxy_file).lines()
+            .map_while(Result::ok)
+            .collect()
+    });
 
-	let client = std::sync::Arc::new(setup_client(proxies));
+    let client = std::sync::Arc::new(setup_client(proxies));
     let option = match_mediafire_valid_url(url);
 
     TOTAL_PROGRESS_BAR.enable_steady_tick(Duration::from_millis(120));
@@ -106,7 +106,7 @@ async fn main() -> Result<()> {
     TOTAL_PROGRESS_BAR.set_message("Downloading");
 
     for _ in 0..max {
-		let client = client.clone();
+        let client = client.clone();
         tokio::spawn(async move {
             loop {
                 let task = QUEUE.pop().await;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -55,7 +55,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_parse_download_link() {
-		let client = setup_client(None);
+        let client = setup_client(None);
         let html = client
             .get("https://www.mediafire.com/file/tb1d35twcp7oj3p")
             .send()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -49,13 +49,14 @@ pub fn check_hash(file_path: &PathBuf, expected_hash: &String) -> Result<bool, s
 
 #[cfg(test)]
 mod tests {
-    use crate::global::CLIENT;
+    use crate::download::setup_client;
 
     use super::*;
 
     #[tokio::test]
     async fn test_parse_download_link() {
-        let html = &CLIENT
+		let client = setup_client(None);
+        let html = client
             .get("https://www.mediafire.com/file/tb1d35twcp7oj3p")
             .send()
             .await


### PR DESCRIPTION
I've added proxy support to mediafire_rs.
Proxies can be supplied from a file, one proxy per line.

**How to test it**

Setup a proxy server (can be done easily with microsocks):
`microsocks -p 1080 -i 127.0.0.1 # Proxy will listen on 127.0.0.1:1080`

Add the proxy address to the proxy file:
```
proxy.txt:
socks5h://127.0.0.1:1080
```
Then run mdrs with the proxy file: `mdrs --proxy proxy.txt <URL>`.

After that, in the proxy server you should see connections being made:
```
client[4] 127.0.0.1: connected to www.mediafire.com:443 # Api request
client[5] 127.0.0.1: connected to download939.mediafire.com:443 # Download
```

I've had to modify how the reqwest client is handled. In order to dynamically build the client based on the proxy list, I've removed it from the lazy_static block and now pass it to function that need it. Notably, I've modified `get_info` and `get_content` so that they use the proxied client instead of using `reqwest::get` directly.