### PR TITLE
feat/ci: build-matrix: added Darwin aarch64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
             target: windows-x64
           - os: macos-latest
             target: darwin-x64
+          - os: macos-latest
+            target: darwin-aarch64
 
     steps:
       - name: Checkout code
@@ -43,7 +45,7 @@ jobs:
           cp target/release/${{ env.BINARY_NAME }}.exe target/release/binaries/${{ matrix.target }}/
 
       - name: Build and copy linux/macos binaries
-        if: ${{ matrix.target == 'linux-x64' || matrix.target == 'darwin-x64'}}
+        if: ${{ matrix.target == 'linux-x64' || matrix.target == 'darwin-x64' || matrix.target == 'darwin-aarch64' }}
         run: |
           cp target/release/${{ env.BINARY_NAME }} target/release/binaries/${{ matrix.target }}/
 


### PR DESCRIPTION
Hi, I don't have Intel computer. Seems also not possible to buy x86_64 computer in Apple Store 🧑‍💻
This should add artifact for Apple Silicon

----
Artifact works as expected<img width="1257" height="402" alt="Screenshot 2026-04-16 at 11 23 52" src="https://github.com/user-attachments/assets/2e676cc9-3ff5-4987-9183-e6acb26ecdcc" />
